### PR TITLE
Add an option for placed shriekers to cause darkness

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
 	id 'fabric-loom' version '1.6-SNAPSHOT'
 	id "fr.brouillard.oss.gradle.jgitver" version "0.9.1"
+	id 'com.github.johnrengelman.shadow' version '8.1.1'
 	id 'maven-publish'
 }
 
@@ -26,11 +27,9 @@ dependencies {
 
 	// Fabric API. This is technically optional, but you probably want it anyway.
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
-	
-	// Uncomment the following line to enable the deprecated Fabric API modules. 
-	// These are included in the Fabric API production distribution and allow you to update your mod to the latest modules at a later more convenient time.
 
-	// modImplementation "net.fabricmc.fabric-api:fabric-api-deprecated:${project.fabric_version}"
+	compileOnly "org.yaml:snakeyaml:2.2"
+	shadow(implementation("org.yaml:snakeyaml:2.2"))
 }
 
 processResources {
@@ -59,6 +58,18 @@ jar {
 	from("LICENSE") {
 		rename { "${it}_${project.base.archivesName.get()}"}
 	}
+}
+
+
+shadowJar {
+	configurations = [project.configurations.shadow]
+	archiveClassifier.set("dev")
+	relocate "org.yaml", "{${project.maven_group}.${project.archivesBaseName}.shadow.org.yaml"
+}
+
+remapJar {
+	dependsOn(shadowJar)
+	inputFile = tasks.shadowJar.archiveFile
 }
 
 jgitver {

--- a/src/main/java/io/github/openbagtwo/shkrieker/ShriekerMod.java
+++ b/src/main/java/io/github/openbagtwo/shkrieker/ShriekerMod.java
@@ -6,6 +6,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ShriekerMod implements ModInitializer {
+
+		public static final String MOD_ID = "shriekier-shriekers";
+		public static final String MOD_NAME = "Shriekier Shriekers";
     public static final Logger LOGGER = LoggerFactory.getLogger("shriekier-shriekers");
 
 	@Override

--- a/src/main/java/io/github/openbagtwo/shkrieker/config/Config.java
+++ b/src/main/java/io/github/openbagtwo/shkrieker/config/Config.java
@@ -115,7 +115,7 @@ public class Config {
    */
   private static Config fromConfigFile() throws FileNotFoundException, ConfigException {
 
-    LOGGER.info("Reading " + MOD_NAME + " configuration from " + config_path);
+    LOGGER.debug("Reading " + MOD_NAME + " configuration from " + config_path);
     FileInputStream configReader = new FileInputStream(config_path.toFile());
     HashMap<String, Object> settings = new HashMap<>((new Yaml()).load(configReader));
 

--- a/src/main/java/io/github/openbagtwo/shkrieker/config/Config.java
+++ b/src/main/java/io/github/openbagtwo/shkrieker/config/Config.java
@@ -1,0 +1,149 @@
+package io.github.openbagtwo.shkrieker.config;
+
+import static io.github.openbagtwo.shkrieker.ShriekerMod.LOGGER;
+import static io.github.openbagtwo.shkrieker.ShriekerMod.MOD_ID;
+import static io.github.openbagtwo.shkrieker.ShriekerMod.MOD_NAME;
+
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import net.fabricmc.loader.api.FabricLoader;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
+
+/**
+ * Shriekier Shriekers' configuration reader / writer
+ */
+public class Config {
+
+  /**
+   * Path to the config file
+   */
+  private static final Path config_path = FabricLoader.getInstance().getConfigDir()
+      .resolve(MOD_ID + ".yaml").toAbsolutePath();
+
+  /**
+   * Whether shriekers should cause darkness
+   */
+  private boolean causeDarkness;
+
+
+  /**
+   * Determine whether shriekers should cause darkness
+   */
+  public boolean getCauseDarkness() {
+    return this.causeDarkness;
+  }
+
+  /**
+   * Default values (that aren't directly accessed by the mod)
+   */
+  private static final boolean DEFAULT_CAUSE_DARKNESS = false;
+
+  /**
+   * Load the mod configuration, however you have to
+   */
+  public static Config loadConfiguration() {
+    Config config;
+    try {
+      config = fromConfigFile();
+      LOGGER.debug("Loaded " + MOD_NAME + " configuration.");
+    } catch (FileNotFoundException e) {
+      LOGGER.warn("No " + MOD_NAME + " configuration file found.");
+      try {
+        writeDefaultConfigFile();
+      } catch (ConfigException writee) {
+        LOGGER.error("Could not write " + MOD_NAME + " configuration:\n" + writee);
+      }
+      config = getDefaultConfiguration();
+    } catch (ConfigException e) {
+      LOGGER.error(MOD_NAME + " configuration is invalid:\n" + e);
+      config = getDefaultConfiguration();
+    }
+    return config;
+  }
+
+  private static final DumperOptions configFormat = new DumperOptions() {{
+    this.setIndent(2);
+    this.setPrettyFlow(true);
+    this.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+  }};
+
+  /**
+   * If the configuration cannot be read in from file for whatever reason, generate and return the
+   * default configuration
+   */
+  private static Config getDefaultConfiguration() {
+    LOGGER.info("Loading default " + MOD_NAME + " configuration");
+    Config config = new Config();
+    config.causeDarkness = DEFAULT_CAUSE_DARKNESS;
+    return config;
+  }
+
+
+  /**
+   * Write a new configuration file with default options
+   *
+   * @throws ConfigException If the writer encounters any sort of IO error (permissions?)
+   */
+  private static void writeDefaultConfigFile() throws ConfigException {
+    FileWriter configWriter;
+    try {
+      configWriter = new FileWriter(config_path.toFile());
+    } catch (IOException e) {
+      throw new ConfigException(
+          "Could not open " + config_path + " for writing.", e
+      );
+    }
+    Map<String, Object> writeme = new LinkedHashMap<>();
+    writeme.put("cause_darkness", DEFAULT_CAUSE_DARKNESS);
+
+    (new Yaml(configFormat)).dump(writeme, configWriter);
+    LOGGER.info("Wrote " + MOD_NAME + " configuration file to " + config_path);
+  }
+
+  /**
+   * Load the settings for the mod, either from file or from defaults
+   *
+   * @return map of str key to the configuration value
+   * @throws ConfigException if the configuration cannot be parsed
+   */
+  private static Config fromConfigFile() throws FileNotFoundException, ConfigException {
+
+    LOGGER.info("Reading " + MOD_NAME + " configuration from " + config_path);
+    FileInputStream configReader = new FileInputStream(config_path.toFile());
+    HashMap<String, Object> settings = new HashMap<>((new Yaml()).load(configReader));
+
+    try {
+      // Now we actually construct the thing
+      boolean causeDarkness = Boolean.parseBoolean(
+          settings.getOrDefault("cause_darkness", DEFAULT_CAUSE_DARKNESS).toString()
+      );
+
+      Config config = new Config();
+      config.causeDarkness = causeDarkness;
+      return config;
+
+    } catch (Exception e) {
+      throw new ConfigException(config_path + " is not a valid " + MOD_NAME + " configuration.", e);
+    }
+  }
+
+  private static class ConfigException extends Exception {
+
+    ConfigException(String message, Exception e) {
+      super(message, e);
+    }
+
+    ConfigException(String message) {
+      super(message);
+    }
+  }
+
+}
+

--- a/src/main/java/io/github/openbagtwo/shkrieker/mixin/ShriekerMixin.java
+++ b/src/main/java/io/github/openbagtwo/shkrieker/mixin/ShriekerMixin.java
@@ -1,14 +1,19 @@
 package io.github.openbagtwo.shkrieker.mixin;
 
+import io.github.openbagtwo.shkrieker.ShriekerMod;
+import io.github.openbagtwo.shkrieker.config.Config;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.SculkShriekerBlock;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.block.entity.BlockEntityType;
 import net.minecraft.block.entity.SculkShriekerBlockEntity;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.mob.WardenEntity;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.World;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -32,6 +37,9 @@ public abstract class ShriekerMixin extends BlockEntity {
   abstract boolean canWarn(ServerWorld world);
 
   @Shadow
+  abstract void playWarningSound(World world);
+
+  @Shadow
   abstract void shriek(ServerWorld world, @Nullable Entity entity);
 
   @Inject(
@@ -45,9 +53,15 @@ public abstract class ShriekerMixin extends BlockEntity {
       if (blockState.get(SculkShriekerBlock.SHRIEKING).booleanValue()) {
         callbackInfo.cancel();
       }
+
       this.setWarningLevel(0);
       if (player == null) {
         this.shriek(world, (Entity) null);
+        if (Config.loadConfiguration().getCauseDarkness()) {
+          this.playWarningSound(world);
+          WardenEntity.addDarknessToClosePlayers(world, Vec3d.ofCenter(this.getPos()), (Entity) null,
+              40);
+        }
         callbackInfo.cancel();
       }
     }


### PR DESCRIPTION
Addresses #1 

Note that, as written, the config file will be checked and loaded on *every* shriek, which means that you can update the setting without needing to reload the game (nice!) but it also might be a lot. As such, I'm not going to merge this until I've tested some extreme cases or implemented some sort of caching. If anyone would like a build to assist me in testing, let me know (or just grab [the built JAR from the CI action](https://github.com/OpenBagTwo/ShriekierShriekers/actions/runs/12791740717/artifacts/2435377482)).