### PR TITLE
Add option for redstone to trigger naturally generated shriekers

### DIFF
--- a/src/main/java/io/github/openbagtwo/shkrieker/config/Config.java
+++ b/src/main/java/io/github/openbagtwo/shkrieker/config/Config.java
@@ -32,18 +32,32 @@ public class Config {
    */
   private boolean causeDarkness;
 
+  /**
+   * Whether naturally-generated shriekers should be triggered by non-player sources
+   * (will not increase warning level)
+   */
+  private boolean applyToNatural;
+
 
   /**
    * Determine whether shriekers should cause darkness
    */
-  public boolean getCauseDarkness() {
+  public boolean getCauseDarknessSetting() {
     return this.causeDarkness;
   }
 
   /**
-   * Default values (that aren't directly accessed by the mod)
+   * Determine whether to apply this mod to natually-generated shriekers
+   */
+  public boolean getApplyToNaturalSetting() {
+    return this.applyToNatural;
+  }
+
+  /**
+   * Default values
    */
   private static final boolean DEFAULT_CAUSE_DARKNESS = false;
+  private static final boolean DEFAULT_APPLY_TO_NATURAL = false;
 
   /**
    * Load the mod configuration, however you have to
@@ -82,6 +96,7 @@ public class Config {
     LOGGER.info("Loading default " + MOD_NAME + " configuration");
     Config config = new Config();
     config.causeDarkness = DEFAULT_CAUSE_DARKNESS;
+    config.applyToNatural = DEFAULT_APPLY_TO_NATURAL;
     return config;
   }
 
@@ -102,6 +117,7 @@ public class Config {
     }
     Map<String, Object> writeme = new LinkedHashMap<>();
     writeme.put("cause_darkness", DEFAULT_CAUSE_DARKNESS);
+    writeme.put("apply_to_natural", DEFAULT_APPLY_TO_NATURAL);
 
     (new Yaml(configFormat)).dump(writeme, configWriter);
     LOGGER.info("Wrote " + MOD_NAME + " configuration file to " + config_path);
@@ -124,9 +140,13 @@ public class Config {
       boolean causeDarkness = Boolean.parseBoolean(
           settings.getOrDefault("cause_darkness", DEFAULT_CAUSE_DARKNESS).toString()
       );
+      boolean applyToNatural = Boolean.parseBoolean(
+          settings.getOrDefault("apply_to_natural", DEFAULT_CAUSE_DARKNESS).toString()
+      );
 
       Config config = new Config();
       config.causeDarkness = causeDarkness;
+      config.applyToNatural = applyToNatural;
       return config;
 
     } catch (Exception e) {

--- a/src/main/java/io/github/openbagtwo/shkrieker/mixin/ShriekerMixin.java
+++ b/src/main/java/io/github/openbagtwo/shkrieker/mixin/ShriekerMixin.java
@@ -1,6 +1,5 @@
 package io.github.openbagtwo.shkrieker.mixin;
 
-import io.github.openbagtwo.shkrieker.ShriekerMod;
 import io.github.openbagtwo.shkrieker.config.Config;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.SculkShriekerBlock;
@@ -25,12 +24,12 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(SculkShriekerBlockEntity.class)
 public abstract class ShriekerMixin extends BlockEntity {
 
-  private final boolean causeDarkness;
+  private final Config config;
 
   public ShriekerMixin(BlockEntityType<?> type,
       BlockPos pos, BlockState state) {
     super(type, pos, state);
-    this.causeDarkness = Config.loadConfiguration().getCauseDarkness();
+    this.config = Config.loadConfiguration();
   }
 
   @Accessor("warningLevel")
@@ -51,18 +50,18 @@ public abstract class ShriekerMixin extends BlockEntity {
       cancellable = true
   )
   public void nonPlayerShriek(ServerWorld world, @Nullable ServerPlayerEntity player, CallbackInfo callbackInfo) {
-    if (!this.canWarn(world)) {
+    if (player == null) {
       BlockState blockState = ((SculkShriekerBlockEntity) (Object) this).getCachedState();
       if (blockState.get(SculkShriekerBlock.SHRIEKING).booleanValue()) {
         callbackInfo.cancel();
       }
-
-      this.setWarningLevel(0);
-      if (player == null) {
+      if (!this.canWarn(world) || config.getApplyToNaturalSetting()) {
+        this.setWarningLevel(0);
         this.shriek(world, (Entity) null);
-        if (this.causeDarkness) {
+        if (this.config.getCauseDarknessSetting()) {
           this.playWarningSound(world);
-          WardenEntity.addDarknessToClosePlayers(world, Vec3d.ofCenter(this.getPos()), (Entity) null,
+          WardenEntity.addDarknessToClosePlayers(world, Vec3d.ofCenter(this.getPos()),
+              (Entity) null,
               40);
         }
         callbackInfo.cancel();

--- a/src/main/java/io/github/openbagtwo/shkrieker/mixin/ShriekerMixin.java
+++ b/src/main/java/io/github/openbagtwo/shkrieker/mixin/ShriekerMixin.java
@@ -25,9 +25,12 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(SculkShriekerBlockEntity.class)
 public abstract class ShriekerMixin extends BlockEntity {
 
+  private final boolean causeDarkness;
+
   public ShriekerMixin(BlockEntityType<?> type,
       BlockPos pos, BlockState state) {
     super(type, pos, state);
+    this.causeDarkness = Config.loadConfiguration().getCauseDarkness();
   }
 
   @Accessor("warningLevel")
@@ -57,7 +60,7 @@ public abstract class ShriekerMixin extends BlockEntity {
       this.setWarningLevel(0);
       if (player == null) {
         this.shriek(world, (Entity) null);
-        if (Config.loadConfiguration().getCauseDarkness()) {
+        if (this.causeDarkness) {
           this.playWarningSound(world);
           WardenEntity.addDarknessToClosePlayers(world, Vec3d.ofCenter(this.getPos()), (Entity) null,
               40);

--- a/src/main/java/io/github/openbagtwo/shkrieker/mixin/ShriekerMixin.java
+++ b/src/main/java/io/github/openbagtwo/shkrieker/mixin/ShriekerMixin.java
@@ -24,12 +24,11 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(SculkShriekerBlockEntity.class)
 public abstract class ShriekerMixin extends BlockEntity {
 
-  private final Config config;
+  private @Nullable Config config;
 
   public ShriekerMixin(BlockEntityType<?> type,
       BlockPos pos, BlockState state) {
     super(type, pos, state);
-    this.config = Config.loadConfiguration();
   }
 
   @Accessor("warningLevel")
@@ -51,11 +50,14 @@ public abstract class ShriekerMixin extends BlockEntity {
   )
   public void nonPlayerShriek(ServerWorld world, @Nullable ServerPlayerEntity player, CallbackInfo callbackInfo) {
     if (player == null) {
+      if (this.config == null) {
+        this.config = Config.loadConfiguration();
+      }
       BlockState blockState = ((SculkShriekerBlockEntity) (Object) this).getCachedState();
       if (blockState.get(SculkShriekerBlock.SHRIEKING).booleanValue()) {
         callbackInfo.cancel();
       }
-      if (!this.canWarn(world) || config.getApplyToNaturalSetting()) {
+      if (!this.canWarn(world) || this.config.getApplyToNaturalSetting()) {
         this.setWarningLevel(0);
         this.shriek(world, (Entity) null);
         if (this.config.getCauseDarknessSetting()) {


### PR DESCRIPTION
Implements #2 / #3 — note that redstone will trigger shriekers to shriek but will *not* summon the Warden or raise the warning level of the shriekers.

That said, I personally think this option is pretty "broken", as shriekers can't be triggered when they're already shrieking, thus making it so an observer-clock trapdoor flipper will effectively disable the Warden from spawning.

This PR also contains a fix for the tech debt introduced in #4: the config file will now only be loaded once per shrieker, and only on the _first_ time the shrieker is triggered by a non-player event.