### PR TITLE
Integrate with modmenu

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,10 @@ base {
 
 repositories {
 	mavenCentral()
+	maven {
+		name = "Terraformers"
+		url = "https://maven.terraformersmc.com/"
+	}
 }
 
 loom {
@@ -25,8 +29,9 @@ dependencies {
 	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
-	// Fabric API. This is technically optional, but you probably want it anyway.
+
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+	modImplementation("com.terraformersmc:modmenu:${project.modmenu_version}")
 
 	compileOnly "org.yaml:snakeyaml:2.2"
 	shadow(implementation("org.yaml:snakeyaml:2.2"))

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,4 @@ archives_base_name=shriekier-shriekers
 
 # Dependencies
 fabric_version=0.97.5+1.20.5
+modmenu_version=10.0.0

--- a/src/main/java/io/github/openbagtwo/shkrieker/config/Config.java
+++ b/src/main/java/io/github/openbagtwo/shkrieker/config/Config.java
@@ -30,13 +30,13 @@ public class Config {
   /**
    * Whether shriekers should cause darkness
    */
-  private boolean causeDarkness;
+  protected boolean causeDarkness;
 
   /**
    * Whether naturally-generated shriekers should be triggered by non-player sources
    * (will not increase warning level)
    */
-  private boolean applyToNatural;
+  protected boolean applyToNatural;
 
 
   /**
@@ -87,6 +87,27 @@ public class Config {
     this.setPrettyFlow(true);
     this.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
   }};
+
+  /**
+   * Write the configuration to file
+   * @throws ConfigException If the writer encounters any sort of IO error (permissions?)
+   */
+  protected void writeConfigToFile() throws ConfigException {
+    FileWriter configWriter;
+    try {
+      configWriter = new FileWriter(config_path.toFile());
+    } catch (IOException e) {
+      throw new ConfigException(
+          "Could not open " + config_path + " for writing.", e
+      );
+    }
+    Map<String, Object> writeme = new LinkedHashMap<>();
+    writeme.put("cause_darkness", this.causeDarkness);
+    writeme.put("apply_to_natural", this.applyToNatural);
+
+    (new Yaml(configFormat)).dump(writeme, configWriter);
+    LOGGER.info("Wrote " + MOD_NAME + " configuration file to " + config_path);
+  }
 
   /**
    * If the configuration cannot be read in from file for whatever reason, generate and return the
@@ -154,7 +175,7 @@ public class Config {
     }
   }
 
-  private static class ConfigException extends Exception {
+  protected static class ConfigException extends Exception {
 
     ConfigException(String message, Exception e) {
       super(message, e);

--- a/src/main/java/io/github/openbagtwo/shkrieker/config/ConfigScreen.java
+++ b/src/main/java/io/github/openbagtwo/shkrieker/config/ConfigScreen.java
@@ -1,0 +1,52 @@
+package io.github.openbagtwo.shkrieker.config;
+
+import io.github.openbagtwo.shkrieker.ShriekerMod;
+import io.github.openbagtwo.shkrieker.config.Config.ConfigException;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.screen.option.GameOptionsScreen;
+import net.minecraft.client.gui.widget.OptionListWidget;
+import net.minecraft.client.option.SimpleOption;
+import net.minecraft.text.Text;
+
+public class ConfigScreen extends GameOptionsScreen {
+
+  private OptionListWidget widgets;
+  private Config config;
+
+  public ConfigScreen(Screen previous) {
+    super(previous, MinecraftClient.getInstance().options, Text.of(ShriekerMod.MOD_NAME));
+    this.config = Config.loadConfiguration();
+  }
+
+
+  @Override
+  protected void init() {
+    this.widgets = this.addDrawableChild(new OptionListWidget(this.client, this.width, this.height, this));
+    this.widgets.addSingleOptionEntry(SimpleOption.ofBoolean("Cause Darkness", this.config.causeDarkness, (value) -> {this.config.causeDarkness = value; }));
+    this.widgets.addSingleOptionEntry(SimpleOption.ofBoolean("Apply to Natural Shriekers", this.config.applyToNatural, (value) -> {this.config.applyToNatural = value;}));
+    super.init();
+  }
+
+  @Override
+  protected void initTabNavigation() {
+    super.initTabNavigation();
+    this.widgets.position(this.width, this.layout);
+  }
+
+  @Override
+  public void render(DrawContext DrawContext, int mouseX, int mouseY, float delta) {
+    super.render(DrawContext, mouseX, mouseY, delta);
+    this.widgets.render(DrawContext, mouseX, mouseY, delta);
+  }
+
+  @Override
+  public void removed() {
+    try {
+      this.config.writeConfigToFile();
+    } catch (ConfigException e) {
+      ShriekerMod.LOGGER.error(String.valueOf(e));
+    }
+  }
+}

--- a/src/main/java/io/github/openbagtwo/shkrieker/config/ModMenu.java
+++ b/src/main/java/io/github/openbagtwo/shkrieker/config/ModMenu.java
@@ -1,0 +1,15 @@
+package io.github.openbagtwo.shkrieker.config;
+
+import com.terraformersmc.modmenu.api.ConfigScreenFactory;
+import com.terraformersmc.modmenu.api.ModMenuApi;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+
+@Environment(EnvType.CLIENT)
+public class ModMenu implements ModMenuApi {
+  @Override
+  public ConfigScreenFactory<?> getModConfigScreenFactory() {
+    return ConfigScreen::new;
+  }
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -18,6 +18,9 @@
 	"entrypoints": {
 		"main": [
 			"io.github.openbagtwo.shkrieker.ShriekerMod"
+		],
+		"modmenu": [
+			"io.github.openbagtwo.shkrieker.config.ModMenu"
 		]
 	},
 	"mixins": [
@@ -25,7 +28,7 @@
 	],
 	"depends": {
 		"fabricloader": ">=0.15.0",
-		"minecraft": ">1.20.4",
+		"minecraft": ">1.20.4,<1.21",
 		"java": ">=21"
 	}
 }


### PR DESCRIPTION
Adds the ability to change the config settings directly via Modmenu. And it doesn't even require a config library!

Sadly, opening the config in any version beyond 1.20.6 causes the game to crash, so this build is now marked as 1.20.5/6 only, and I'll need to produce separate builds for modern versions of the game.